### PR TITLE
fix: allow using in select

### DIFF
--- a/.github/ISSUE_TEMPLATE/.github/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+# Reason for This PR
+
+`[Author TODO: add issue # or explain reasoning.]`
+
+## Description of Changes
+
+`[Author TODO: add description of changes.]`
+
+## License Acceptance
+
+By submitting this pull request, I confirm that my contribution is made under
+the terms of the MIT license.
+
+## PR Checklist
+
+`[Author TODO: Meet these criteria.]`
+`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`
+
+- [ ] All commits in this PR are signed (`git commit -s`).
+- [ ] The reason for this PR is clearly provided (issue no. or explanation).
+- [ ] The description of changes is clear and encompassing.
+- [ ] Any required documentation changes (code and docs) are included in this PR.
+- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
+- [ ] All added/changed functionality is tested.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [stable]
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v6 # action page: <https://github.com/actions/setup-go>

--- a/binary_heap_test.go
+++ b/binary_heap_test.go
@@ -165,7 +165,7 @@ func TestNewPriorityQueue(t *testing.T) {
 				return
 			case item := <-itemCh:
 				atomic.AddUint64(&getPerSec, 1)
-				_ = item
+				require.NotNil(t, item)
 			}
 		}
 	}()

--- a/binary_heap_test.go
+++ b/binary_heap_test.go
@@ -163,7 +163,10 @@ func TestNewPriorityQueue(t *testing.T) {
 			select {
 			case <-stopCh:
 				return
-			case item := <-itemCh:
+			case item, cl := <-itemCh:
+				if !cl {
+					return
+				}
 				atomic.AddUint64(&getPerSec, 1)
 				require.NotNil(t, item)
 			}
@@ -183,6 +186,8 @@ func TestNewPriorityQueue(t *testing.T) {
 	}()
 
 	time.Sleep(time.Second * 5)
+
+	pq.Stop()
 	stopCh <- struct{}{}
 	stopCh <- struct{}{}
 	stopCh <- struct{}{}
@@ -237,7 +242,7 @@ func TestItemPeek(t *testing.T) {
 	}
 
 	/*
-		first item should be extracted not less than 5 seconds after we call ExtractMin
+		the first item should be extracted not less than 5 seconds after we call ExtractMin
 		5 seconds is a minimum timeout for our items
 	*/
 	bh := NewBinHeap[Item](100)

--- a/binary_heap_test.go
+++ b/binary_heap_test.go
@@ -188,10 +188,16 @@ func TestNewPriorityQueue(t *testing.T) {
 	time.Sleep(time.Second * 5)
 
 	pq.Stop()
-	stopCh <- struct{}{}
-	stopCh <- struct{}{}
-	stopCh <- struct{}{}
-	stopCh <- struct{}{}
+
+	for range 4 {
+		select {
+		case stopCh <- struct{}{}:
+		default:
+			// it might happed that we already exited from one of the goroutines
+			// by the signal from the PQ.Stop() method
+			continue
+		}
+	}
 }
 
 func TestNewItemWithTimeout(t *testing.T) {


### PR DESCRIPTION
# Reason for This PR

- ref: https://github.com/roadrunner-server/roadrunner/issues/2194

## Description of Changes

- Use a channel for the extract min binary-heap operation to be used in the select statement and allow for faster cancellation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a non-blocking, channel-based extraction interface for concurrent retrieval and a graceful shutdown for background processing.

* Breaking Changes
  * Removed the previous synchronous extraction API; consumers must use the new non-blocking retrieval approach.

* Behavior
  * Extraction is now asynchronous while preserving item ordering and results.

* Refactor
  * Concurrency reworked to background processing with channel-driven delivery.

* Documentation
  * Added a PR template to standardize change descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->